### PR TITLE
Set up Travis on new Rails apps

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -26,9 +26,15 @@ On mac, you can use:
 brew install hub
 ```
 
+### Features
+- Installs common gems
+- Sets up Rspec
+- Creates a Github repo
+- Creates a staging app in Heroku
+- Sets up [Travis](https://travis-ci.com/abtion/Wokshop)
+
 #### TODO
 
-- Create app on [Travis](https://travis-ci.com/abtion/Wokshop)
 - Dockerize the app with Docker and Docker-Compose
 - Add basic scripts to run the app and other convenient actions
 - Add standard README

--- a/rails/muffi_template/.travis.yml
+++ b/rails/muffi_template/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+cache: bundler
+bundler_args: "--without production"
+services:
+- postgresql
+sudo: false
+before_script:
+- bundle install
+- RAILS_ENV=development bundle exec rake db:create db:migrate
+script:
+  - bundle exec rubocop
+  - bundle exec rspec

--- a/rails/rails-template.rb
+++ b/rails/rails-template.rb
@@ -29,6 +29,7 @@ after_bundle do
   # Setup Rspec
   run "rm -rf test"
   directory 'spec', "spec"
+  copy_file '.travis.yml'
 
   git :init
   git add: "."
@@ -58,6 +59,7 @@ after_bundle do
   puts "Rspec is ready to run. You can even use Factories."
   puts "We've created a git repo and pushed it to Github. You shoud be able to find it at: github.com/abtion/#{app_name}"
   puts "We've created a Staging app in Heroku. You shoud be able to find it at: https://#{parameterize_app_name}-staging.herokuapp.com/"
+  puts "Next time you make a commit, your test suit will run on TravisCI."
   puts ""
   puts ""
   puts ""


### PR DESCRIPTION
Our Github account has Travis CI app installed in all our repos. A .travis.yml file is enough for configuring an app.

Github services are deprecated in favor of apps:
![](https://cl.ly/1f3k120k3E0U/Image%202018-06-08%20at%201.07.05%20PM.png)