### PR TITLE
[WIP] Add preferred services for sms

### DIFF
--- a/preferred-services.md
+++ b/preferred-services.md
@@ -3,5 +3,3 @@
 ## Sending and receiving SMS
 We prefer to use [LinkMobility](https://www.linkmobility.com/) for sending and receiving sms.
 You can read the docs [here](https://linkmobility.atlassian.net/wiki/spaces/COOL/pages/26017821/LINK+Mobility+DK+Rest+API+v2).
-
-- https://linkmobility.atlassian.net/wiki/spaces/COOL/pages/26017833/API

--- a/preferred-services.md
+++ b/preferred-services.md
@@ -1,0 +1,7 @@
+# Preferred Services
+
+## Sending and receiving SMS
+We prefer to use [LinkMobility](https://www.linkmobility.com/) for sending and receiving sms.
+You can read the docs [here](https://linkmobility.atlassian.net/wiki/spaces/COOL/pages/26017821/LINK+Mobility+DK+Rest+API+v2).
+
+- https://linkmobility.atlassian.net/wiki/spaces/COOL/pages/26017833/API


### PR DESCRIPTION
**it looks like this:**
---



# Preferred Services

 ## Sending and receiving SMS
We prefer to use [LinkMobility](https://www.linkmobility.com/) for sending and receiving sms.
You can read the docs [here](https://linkmobility.atlassian.net/wiki/spaces/COOL/pages/26017821/LINK+Mobility+DK+Rest+API+v2).