### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/rails/template.rb
+++ b/rails/template.rb
@@ -43,10 +43,6 @@ gem_group :test do
   gem "factory_bot_rails", "~> 4.0"
 end
 
-gem_group :production do
-  gem 'rails_12factor'
-end
-
 gem "rubocop", require: false
 
 after_bundle do


### PR DESCRIPTION
This gem is not required in Rails 5
See: https://github.com/heroku/rails_12factor#rails-5