### PR TITLE
Remove factory_bot version specification

### DIFF
--- a/rails/template.rb
+++ b/rails/template.rb
@@ -40,7 +40,7 @@ gem_group :development, :test do
 end
 
 gem_group :test do
-  gem "factory_bot_rails", "~> 4.0"
+  gem "factory_bot_rails"
 end
 
 gem_group :production do


### PR DESCRIPTION
Remove the Gemfile version specifier from factory_bot so we can use the
most recent version. (currently: 5.0.0)