### PR TITLE
Check for required dependencies

### DIFF
--- a/rails/template.rb
+++ b/rails/template.rb
@@ -2,6 +2,19 @@ require 'pry'
 
 # Run this with: rails new my_app -m https://raw.githubusercontent.com/abtion/guidelines/master/rails/template.rb
 
+#
+# Check that we have all the required dependencies
+#
+def dependencies_present?(dependencies)
+  dependencies.map do |dependency|
+    (system "which #{dependency} > /dev/null").tap { |present|
+      puts "#{dependency} not installed\n" unless present
+    }
+  end.all?
+end
+
+raise "ABORTED: Install missing dependencies." unless dependencies_present?(%w[git hub heroku])
+
 # Add this template directory to source_paths so that actions like
 # copy_file and template resolve against our source files. If this file was
 # invoked remotely via HTTP, that means the files are not present locally.


### PR DESCRIPTION
The template script assumes we have some dependencies in place. If they're not there things fail in unhelpful ways, but the final report still says everything worked.

This PR makes sure that we have got the required dependences (`git`, `hub`, `heroku`) installed before running everything.