### PR TITLE
Allow cloning a different repo

### DIFF
--- a/rails/template.rb
+++ b/rails/template.rb
@@ -12,9 +12,10 @@ def add_template_repository_to_source_path
     tempdir = Dir.mktmpdir("template-tmp")
     source_paths.unshift(tempdir + "/rails/muffi_template")
     at_exit {FileUtils.remove_entry(tempdir)}
+    repository = __FILE__.match(%r{\.githubusercontent\.com/(?<repository>[^/]*/[^/]*)/})[:repository]
     git clone: [
       "--quiet",
-      "https://github.com/abtion/guidelines.git",
+      "https://github.com/#{repository}.git",
       tempdir
     ].map(&:shellescape).join(" ")
   else


### PR DESCRIPTION
The current script assumes that the repository you are going to need to clone is `abtion/guidelines` (this repository.) which is fine, unless you're using a fork, in which case you'd rather use the fork.

This PR parses the command line argument that specifies the the `template.rb` and works out the correct repository to use from that.

It also fixes a bug that caused the script to fail if you were using a locally checked out version of the `template.rb` script.