### PR TITLE
Add guidelines for American English

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -1,0 +1,7 @@
+# Best Practices
+
+## Language
+
+All code, comments and documentation should be written in American English.
+This includes model attributes, variable names, methods and classes.
+


### PR DESCRIPTION
We happened to have this issue in one of our projects, and needed to align. We think this should be a default at Abtion.