### PR TITLE
Add guidelines for code reviews.

### DIFF
--- a/code-reviews/README.md
+++ b/code-reviews/README.md
@@ -27,8 +27,7 @@
   you changed something.
 - Every comment should be seen as a suggestion. Ask questions until you
   understand it and agree that the change would be an improvement.
-- Tag the appropriate people in the PR (`git blame` can be useful here. Bonus
-  points for aliasing `git blame` to `git praise`).
+- Tag the appropriate people in the PR (`git annotate` can be useful here).
 - Add a link to the ticket in Asana, Trello, JIRA etc.
 - For frontend changes, consider including GIFs or screenshots showing what has
   changed.

--- a/code-reviews/README.md
+++ b/code-reviews/README.md
@@ -1,0 +1,44 @@
+# Code reviews
+## General
+- For discussions that are happening outside a PR, summarize them afterwards as
+  a comment for future reference.
+- Code reviews are discussions where everybody is encouraged to chime in
+  irrespective of their job title.
+- Words such as "just", "simply", and "easily" tend to pass judgment about the
+  difficulty of a problem.
+
+## Giving feedback
+- Always read your comment from the perspective of the author of the pull
+  request.
+- If you see something good, say something good.
+- Suggest specific changes rather than using phrases such as "What do you think
+  about clarifying X?" and explain why a change might be appropriate.
+- Avoid selective ownership of code ("yours", "mine" etc.).
+- Consider reading the code changes from the bottom to the top to catch issues
+  that others might overlook (as most people tend to read the code from the
+  top to bottom).
+
+## Receiving feedback
+- The feedback is not a critique of you but the code. 
+- Be grateful for the reviewer's suggestions.
+- Provide context to the pull request and explain the motivation for it.
+- Add comments to specific lines where you want feedback or have questions.
+- Add comments to specific lines where you anticipate questions and explain why
+  you changed something.
+- Every comment should be seen as a suggestion. Ask questions until you
+  understand it and agree that the change would be an improvement.
+- Tag the appropriate people in the PR (`git blame` can be useful here. Bonus
+  points for aliasing `git blame` to `git praise`).
+- Add a link to the ticket in Asana, Trello, JIRA etc.
+- For frontend changes, consider including GIFs or screenshots showing what has
+  changed.
+
+## Additional reading
+- [5 Tips for More Helpful Code Reviews](https://thoughtbot.com/blog/five-tips-for-more-helpful-code-reviews)
+- [Barsoom developer's handbook](https://github.com/barsoom/devbook)
+- [Building Team Trust with Code Reviews](https://mpgarate.com/2020/05/27/building-trust-with-code-reviews.html)
+- [Code Review](https://github.com/thoughtbot/guides/tree/master/code-review)
+- [Expectations, Outcomes, and Challenges of Modern Code Review](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/ICSE202013-codereview.pdf)
+- [How to Give and Get Better Code Reviews](https://hackernoon.com/how-to-give-and-get-better-code-reviews-e011c3cda55e)
+- [Implementing a Strong Code Review Culture](https://www.youtube.com/watch?v=PJjmw9TRB7s)
+- [Tips for Code Review](https://thoughtbot.com/upcase/videos/tips-for-code-review)


### PR DESCRIPTION
This pull request adds a few guidelines on how to both give and receive code reviews. The guidelines should work for code reviews on GitHub as well as in-person code reviews.

Let me know if something is unclear, or you have suggestions for improvements.