### PR TITLE
Add more "Impactful" items to the career ladder.

### DIFF
--- a/career/ladder.md
+++ b/career/ladder.md
@@ -22,7 +22,7 @@ Here are some examples of other career ladders:
 
 ## Dev Values: Impactful, Simple, Test-Driven, Iterative, Communicative, Respectful, Skilled
 
-### Level 1
+### Level 1 - Associate Software Engineer
 #### Impactful
 - [ ] Contributes positively to the development of one or multiple apps.
 
@@ -53,7 +53,7 @@ Here are some examples of other career ladders:
 - [ ] Can write code in at least one language.
 - [ ] Broad knowledge of main CS + XP concepts.
 
-### Level 2
+### Level 2 - Software Engineer
 
 #### Impactful
 - [ ] Capable of providing support for their area, including systems they are not familiar with.
@@ -84,7 +84,7 @@ Here are some examples of other career ladders:
 - [ ] Understands what differentiates their favorite language from others. Knows what the language is useful for and when it is not the best option.
 - [ ] Understand where to place logic in their favorite framework.
 
-### Level 3
+### Level 3 - Software Engineer
 
 #### Impactful
 - [ ] Drives tasks from internal meetings and parks them nicely in internal acceptance.
@@ -119,7 +119,7 @@ Here are some examples of other career ladders:
 - [ ] Can write code in at least two technical areas (frontend, backend, digital infrastructure). Ensures the completion of the tasks in their two areas of expertise.
 - [ ] Can debug issues occurring across multiple levels of the stack.
 
-### Level 4
+### Level 4 - Senior Software Engineer
 
 #### Impactful
 - [ ] Partners with project managers and designers to drive technical decisions based on the highest output for all parties' needs.
@@ -154,7 +154,7 @@ Here are some examples of other career ladders:
 - [ ] Demonstrates the ability to succeed in a wide range of complex situations across multiple axes: e.g., scale, uncertainty, interconnectedness.
 - [ ] Researches and proposes new technologies to the team(s).
 
-### Level 5
+### Level 5 - Senior Software Engineer
 
 #### Impactful
 - [ ] Is recognized as a helpful consultant that consistently delivers high-value solutions for real problems.
@@ -188,7 +188,7 @@ Here are some examples of other career ladders:
 - [ ] Sought out for technical guidance.
 - [ ] Anticipates technical issues at a product level and works with design to avoid them.
 
-### Level 6
+### Level 6 - Principal Software Engineer
 
 #### Impactful
 - [ ] Has made an obvious positive impact on the entire company's technical trajectory.

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -220,7 +220,7 @@ Here are some examples of other career ladders:
 ### Level 6 - Principal Software Engineer
 
 #### Impactful
-- [ ] Plays a key role of the technical direction of the company and has
+- [ ] Plays a key role in the technical direction of the company and has
   introduced positive changes across multiple teams.
 - [ ] Focuses on the growth of their team's productivity and career.
 - [ ] Provides executives with high-level guidance on technical decisions when

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -61,8 +61,6 @@ Here are some examples of other career ladders:
 
 #### Impactful
 - [ ] Capable of providing support for their area, including systems they are not familiar with.
-- [ ] Requires minimal guidance from seniors and can help unblock juniors when
-  necessary.
 
 #### Simple
 - [ ] Creates simple method / functions that most static code analysers would accept.
@@ -102,6 +100,8 @@ Here are some examples of other career ladders:
 
 #### Impactful
 - [ ] Drives tasks from internal meetings and parks them nicely in internal acceptance.
+- [ ] Requires minimal guidance from seniors and can help unblock juniors when
+  necessary.
 - [ ] Proactively seeks out to unblock colleagues when they are struggling with
   a task.
 - [ ] Has a track record of embracing big challenges and turning them into

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -61,6 +61,16 @@ Here are some examples of other career ladders:
 
 #### Impactful
 - [ ] Capable of providing support for their area, including systems they are not familiar with.
+- [ ] Understands and can provide a high-level overview of the current milestone
+  of a project.
+- [ ] Focuses on building strong relationships with their team, direct manager,
+  and project manager/product owner.
+- [ ] Identifies unclear requirements and reaches out to relevant stakeholders
+  to clarify issues.
+- [ ] Reliably do what they say they will, and communicates promptly if an issue
+  arises.
+- [ ] Requires minimal guidance from seniors and can help unblock juniors when
+  necessary.
 
 #### Simple
 - [ ] Creates simple method / functions that most static code analysers would accept.

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -220,8 +220,11 @@ Here are some examples of other career ladders:
 ### Level 6 - Principal Software Engineer
 
 #### Impactful
-- [ ] Has made an obvious positive impact on the entire company's technical trajectory.
-- [ ] Focused on and responsible for their team's productivity and growth.
+- [ ] Plays a key role of the technical direction of the company and has
+  introduced positive changes across multiple teams.
+- [ ] Focuses on the growth of their team's productivity and career.
+- [ ] Provides executives with high-level guidance on technical decisions when
+  necessary.
 
 #### Simple
 - [ ] Has a clear understanding of long term maintenance costs and tradeoffs related to simplifying code

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -60,7 +60,8 @@ Here are some examples of other career ladders:
 ### Level 2 - Software Engineer
 
 #### Impactful
-- [ ] Capable of providing support for their area, including systems they are not familiar with.
+- [ ] Consistently closes tasks in their area of expertise collaborating with
+  less experienced developers.
 
 #### Simple
 - [ ] Creates simple method / functions that most static code analysers would accept.
@@ -102,10 +103,9 @@ Here are some examples of other career ladders:
 - [ ] Drives tasks from internal meetings and parks them nicely in internal acceptance.
 - [ ] Requires minimal guidance from seniors and can help unblock juniors when
   necessary.
-- [ ] Proactively seeks out to unblock colleagues when they are struggling with
-  a task.
-- [ ] Has a track record of embracing big challenges and turning them into
-  successes.
+- [ ] Distinguishes between what work is relevant now, and what work can be
+  tackled later.
+- [ ] Pushes tasks forward in lack of complete context. Works with uncertainty.
 
 #### Simple
 - [ ] Capable of prioritizing tasks. Avoids getting caught up in unimportant details and focuses on delivering value to the client (avoids bike-shedding).
@@ -133,7 +133,10 @@ Here are some examples of other career ladders:
 - [ ] Can introduce a new member to the project.
 
 #### Respectful teammate
+- [ ] Has taught other developers to pair program.
 - [ ] Actively participates in feedback for team members.
+- [ ] Proactively seeks out to unblock colleagues when they are struggling with
+  a task including those that are outside their area of expertise.
 
 #### Technical skills
 - [ ] Can write code in at least two technical areas (frontend, backend, digital infrastructure). Ensures the completion of the tasks in their two areas of expertise.
@@ -144,6 +147,8 @@ Here are some examples of other career ladders:
 #### Impactful
 - [ ] Partners with project managers and designers to drive technical decisions based on the highest output for all parties' needs.
 - [ ] Drives tasks from client research to client acceptance.
+- [ ] Has a track record of embracing big challenges and turning them into
+  successes.
 
 #### Simple
 - [ ] Does not over-optimize. Understands when code is "good-enough".
@@ -164,9 +169,8 @@ Here are some examples of other career ladders:
 - [ ] Understands and can provide a detailed overview of a project.
 - [ ] Focuses on building strong relationships with their team, direct
   manager, and other seniors across the organization.
-- [ ] Can help PM cultivate an Asana board.
-- [ ] Understands kanban.
-- [ ] Can teach juniors to pair program.
+- [ ] Aligns team on expectations.
+- [ ] Cultivates an Asana board with the PM.
 
 #### Respectful teammate
 - [ ] Makes others better through code reviews, thorough documentation, technical guidance, and mentoring.
@@ -204,7 +208,6 @@ Here are some examples of other career ladders:
 #### Communication
 - [ ] Ensures proactively that the relevant stakeholders are informed if the
   team is running into issues.
-- [ ] Aligns team on expectations.
 - [ ] Identifies miscommunications and solves them before they become a problem.
 - [ ] Identifies and proposes strategies around technical problems affecting their team and communicates standards.
 
@@ -244,7 +247,6 @@ Here are some examples of other career ladders:
 #### Communication
 - [ ] Provides executives with high-level guidance on technical decisions when
   necessary.
-- [ ] Works to define tasks in Asana and can mentor juniors in defining them.
 - [ ] Can collaborate with a client about estimates and prioritization.
 
 #### Respectful teammate

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -24,7 +24,11 @@ Here are some examples of other career ladders:
 
 ### Level 1 - Associate Software Engineer
 #### Impactful
-- [ ] Contributes positively to the development of one or multiple apps.
+- [ ] Consistently completes work on a task-level within one or multiple apps.
+- [ ] Focuses on building strong relationships with their team and direct
+  manager.
+- [ ] Proactively reaches out for help when struggling with a task.
+- [ ] Actively seeks feedback to improve from colleagues and receives it well.
 
 #### Simple
 - [ ] Is working on naming variables and learning to extract methods.

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -102,7 +102,13 @@ Here are some examples of other career ladders:
 
 #### Impactful
 - [ ] Drives tasks from internal meetings and parks them nicely in internal acceptance.
-- [ ] Drives tasks from internal meetings and parks them nicely in internal acceptance.
+- [ ] Understands and can provide a high-level overview of a project.
+- [ ] Consistently facilitates communication with project managers/product
+  owners for one or multiple apps.
+- [ ] Proactively seeks out to unblock colleagues when they are struggling with
+  a task.
+- [ ] Has a track record of embracing big challenges and turning them into
+  successes.
 
 #### Simple
 - [ ] Capable of prioritizing tasks. Avoids getting caught up in unimportant details and focuses on delivering value to the client (avoids bike-shedding).

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -144,6 +144,9 @@ Here are some examples of other career ladders:
 #### Impactful
 - [ ] Partners with project managers and designers to drive technical decisions based on the highest output for all parties' needs.
 - [ ] Drives tasks from client research to client acceptance.
+- [ ] Understands and can provide a detailed overview of a project.
+- [ ] Focuses on building strong relationships with their team, direct
+  manager, and other seniors across the organization.
 
 #### Simple
 - [ ] Does not over-optimize. Understands when code is "good-enough".

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -181,6 +181,12 @@ Here are some examples of other career ladders:
 
 #### Impactful
 - [ ] Is recognized as a helpful consultant that consistently delivers high-value solutions for real problems.
+- [ ] Reviews projects critically and ensures that they are divided into parts
+  that can be solved in isolation most of the time.
+- [ ] Consistently shows initiative and identifies areas of improvements for
+  themselves and the team.
+- [ ] Ensures proactively that the relevant stakeholders are informed if the
+  team is running into issues.
 
 #### Simple
 - [ ] Creates architecture that enables many potential futures without knowing exactly what the future is.

--- a/career/ladder.md
+++ b/career/ladder.md
@@ -25,10 +25,6 @@ Here are some examples of other career ladders:
 ### Level 1 - Associate Software Engineer
 #### Impactful
 - [ ] Consistently completes work on a task-level within one or multiple apps.
-- [ ] Focuses on building strong relationships with their team and direct
-  manager.
-- [ ] Proactively reaches out for help when struggling with a task.
-- [ ] Actively seeks feedback to improve from colleagues and receives it well.
 
 #### Simple
 - [ ] Is working on naming variables and learning to extract methods.
@@ -43,6 +39,10 @@ Here are some examples of other career ladders:
 - [ ] Understands red-green-refactor.
 
 #### Communication
+- [ ] Focuses on building strong relationships with their team and direct
+  manager.
+- [ ] Proactively reaches out for help when struggling with a task.
+- [ ] Actively seeks feedback to improve from colleagues and receives it well.
 - [ ] Updates Asana.
 - [ ] Comes prepared for meetings.
 - [ ] Uses time tracking tools and vacation notifications.
@@ -61,14 +61,6 @@ Here are some examples of other career ladders:
 
 #### Impactful
 - [ ] Capable of providing support for their area, including systems they are not familiar with.
-- [ ] Understands and can provide a high-level overview of the current milestone
-  of a project.
-- [ ] Focuses on building strong relationships with their team, direct manager,
-  and project manager/product owner.
-- [ ] Identifies unclear requirements and reaches out to relevant stakeholders
-  to clarify issues.
-- [ ] Reliably do what they say they will, and communicates promptly if an issue
-  arises.
 - [ ] Requires minimal guidance from seniors and can help unblock juniors when
   necessary.
 
@@ -87,6 +79,14 @@ Here are some examples of other career ladders:
 - [ ] Delivers working code with each commit.
 
 #### Communication
+- [ ] Understands and can provide a high-level overview of the current milestone
+  of a project.
+- [ ] Focuses on building strong relationships with their team, direct manager,
+  and project manager/product owner.
+- [ ] Identifies unclear requirements and reaches out to relevant stakeholders
+  to clarify issues.
+- [ ] Reliably do what they say they will, and communicates promptly if an issue
+  arises.
 - [ ] Hosts retros.
 - [ ] Can compose a PR and provide feedback on them.
 
@@ -102,9 +102,6 @@ Here are some examples of other career ladders:
 
 #### Impactful
 - [ ] Drives tasks from internal meetings and parks them nicely in internal acceptance.
-- [ ] Understands and can provide a high-level overview of a project.
-- [ ] Consistently facilitates communication with project managers/product
-  owners for one or multiple apps.
 - [ ] Proactively seeks out to unblock colleagues when they are struggling with
   a task.
 - [ ] Has a track record of embracing big challenges and turning them into
@@ -128,6 +125,9 @@ Here are some examples of other career ladders:
 - [ ] Uses time management techniques
 
 #### Communication
+- [ ] Understands and can provide a high-level overview of a project.
+- [ ] Consistently facilitates communication with project managers/product
+  owners for one or multiple apps.
 - [ ] Is proficient with pair programming.
 - [ ] Can write user stories.
 - [ ] Can introduce a new member to the project.
@@ -144,9 +144,6 @@ Here are some examples of other career ladders:
 #### Impactful
 - [ ] Partners with project managers and designers to drive technical decisions based on the highest output for all parties' needs.
 - [ ] Drives tasks from client research to client acceptance.
-- [ ] Understands and can provide a detailed overview of a project.
-- [ ] Focuses on building strong relationships with their team, direct
-  manager, and other seniors across the organization.
 
 #### Simple
 - [ ] Does not over-optimize. Understands when code is "good-enough".
@@ -164,6 +161,9 @@ Here are some examples of other career ladders:
 - [ ] Well-composed commit narratives in commit flows.
 
 #### Communication
+- [ ] Understands and can provide a detailed overview of a project.
+- [ ] Focuses on building strong relationships with their team, direct
+  manager, and other seniors across the organization.
 - [ ] Can help PM cultivate an Asana board.
 - [ ] Understands kanban.
 - [ ] Can teach juniors to pair program.
@@ -185,8 +185,6 @@ Here are some examples of other career ladders:
   that can be solved in isolation most of the time.
 - [ ] Consistently shows initiative and identifies areas of improvements for
   themselves and the team.
-- [ ] Ensures proactively that the relevant stakeholders are informed if the
-  team is running into issues.
 
 #### Simple
 - [ ] Creates architecture that enables many potential futures without knowing exactly what the future is.
@@ -204,6 +202,8 @@ Here are some examples of other career ladders:
 - [ ] Can guide an IPM and team reflection.
 
 #### Communication
+- [ ] Ensures proactively that the relevant stakeholders are informed if the
+  team is running into issues.
 - [ ] Aligns team on expectations.
 - [ ] Identifies miscommunications and solves them before they become a problem.
 - [ ] Identifies and proposes strategies around technical problems affecting their team and communicates standards.
@@ -223,8 +223,6 @@ Here are some examples of other career ladders:
 - [ ] Plays a key role in the technical direction of the company and has
   introduced positive changes across multiple teams.
 - [ ] Focuses on the growth of their team's productivity and career.
-- [ ] Provides executives with high-level guidance on technical decisions when
-  necessary.
 
 #### Simple
 - [ ] Has a clear understanding of long term maintenance costs and tradeoffs related to simplifying code
@@ -244,6 +242,8 @@ Here are some examples of other career ladders:
 - [ ] Brings new working-methods that improve team performance.
 
 #### Communication
+- [ ] Provides executives with high-level guidance on technical decisions when
+  necessary.
 - [ ] Works to define tasks in Asana and can mentor juniors in defining them.
 - [ ] Can collaborate with a client about estimates and prioritization.
 


### PR DESCRIPTION
As mentioned in https://github.com/abtion/guidelines/pull/51, the career ladder is currently being reviewed and updated. This pull request suggests the following titles for the six levels:

* Level 1: Associate Software Engineer
* Level 2: Software Engineer
* Level 3: Software Engineer
* Level 4: Senior Software Engineer
* Level 5: Senior Software Engineer
* Level 6: Principal Software Engineer

In addition, it adds more points under the "Impactful" section of each level to explain the desired behavior of somebody on that particular level. Some of these points should perhaps be moved to "Communication", although communication is, of course, impactful in itself.