### PR TITLE
Add EM career ladder.

### DIFF
--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -78,10 +78,49 @@ make pull requests with suggestions for improvements.
   projects.
 
 ## Level 5: Engineering Manager
+### Impactful
+- TBD.
+
+### Coaching and mentoring
+- TBD.
+
+### Management/HR
+- TBD.
+
+## Technical skills
+- TBD.
+
+### Communication and facilitation
 - TBD.
 
 ## Level 6: Senior Engineering Manager
+### Impactful
+- TBD.
+
+### Coaching and mentoring
+- TBD.
+
+### Management/HR
+- TBD.
+
+## Technical skills
+- TBD.
+
+### Communication and facilitation
 - TBD.
 
 ## Level 7: Senior Engineering Manager
+### Impactful
+- TBD.
+
+### Coaching and mentoring
+- TBD.
+
+### Management/HR
+- TBD.
+
+## Technical skills
+- TBD.
+
+### Communication and facilitation
 - TBD.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -72,7 +72,8 @@ make pull requests with suggestions for improvements.
 
 ## Level 5: Engineering Manager
 ### Impactful
-- TBD.
+- [ ] Manages a set of people consisting of approximately six to eight direct
+  reports.
 
 ### Coaching and mentoring
 - TBD.
@@ -85,7 +86,8 @@ make pull requests with suggestions for improvements.
 
 ## Level 6: Senior Engineering Manager
 ### Impactful
-- TBD.
+- [ ] Manages a set of people consisting of approximately eight or more direct
+  reports.
 
 ### Coaching and mentoring
 - TBD.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -8,6 +8,14 @@ before they can transition into a role as an Engineering Manager. This is
 required as we believe it is important that you have grown your technical
 skills to a certain level before you start leading highly technical individuals.
 
+Engineering managers are expected to be able to check off most items under
+"Impactful", "Simple", "Communication" and "Respectful teammate" for the
+corresponding level in the [IC career
+ladder](https://github.com/abtion/guidelines/blob/main/career/ladder.md).
+Although you will not be evaluated on your ability to test highly complex logic,
+we believe testing is an essential engineering practice that you will continue
+honing and teaching.
+
 While the engineering management track includes non-development tasks, it is
 worth pointing out that most of your time will still be spent on development and
 other client-focused work. You will gradually spend more time on managerial

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -1,6 +1,6 @@
 # Engineering Management Career Ladder
 This career ladder serves to give an overview of how you can progress your
-career at Abtion and become an Engineering Manager.
+career at Abtion and become an Engineering Manager (EM).
 
 As a prerequisite, we require people to have moved beyond level 2 on our [IC
 career ladder](https://github.com/abtion/guidelines/blob/main/career/ladder.md)

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -100,7 +100,8 @@ projects.
   the growth of their direct reports.
 
 ### Management/HR
-- TBD.
+- [ ] Has established a track record of retaining and attracting excellent
+  developers.
 
 ### Communication and facilitation
 - [ ] Uses their experience to identify headcount needs when planning new

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -11,7 +11,7 @@ skills to a certain level before you start leading highly technical individuals.
 Any feedback on this career ladder is appreciated, and we encourage that you
 make pull requests with suggestions for improvements.
 
-## Level 1
+## Level 3: Associate Engineering Manager
 ### Impactful
 - [ ] Manages a set of people consisting of four to five direct reports.
 - [ ] Has the required maturity to manage individual contributors at a higher
@@ -63,14 +63,14 @@ make pull requests with suggestions for improvements.
 - [ ] Ensures new hires are onboarded successfully in collaboration with
   relevant parties.
 
-## Level 2
+## Level 4: Engineering Manager
 - TBD.
 
-## Level 3
+## Level 5: Engineering Manager
 - TBD.
 
-## Level 4
+## Level 6: Senior Engineering Manager
 - TBD.
 
-## Level 5
+## Level 7: Senior Engineering Manager
 - TBD.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -1,0 +1,76 @@
+# Engineering Management Career Ladder
+This career ladder serves to give an overview of how you can progress your
+career at Abtion and become an Engineering Manager.
+
+As a prerequisite, we require people to have moved beyond level 2 on our [IC
+career ladder](https://github.com/abtion/guidelines/blob/main/career/ladder.md)
+before they can transition into a role as an Engineering Manager. This is
+required as we believe it is important that you have grown your technical
+skills to a certain level before you start leading highly technical individuals.
+
+Any feedback on this career ladder is appreciated, and we encourage that you
+make pull requests with suggestions for improvements.
+
+## Level 1
+### Impactful
+- [ ] Manages a set of people consisting of four to five direct reports.
+- [ ] Has the required maturity to manage individual contributors at a higher
+  skill level than themselves.
+- [ ] Identifies growth opportunities for their direct reports and proactively
+  ensures that these opportunities are pursued.
+- [ ] Adjusts processes and practices regularly to maximize the efficiency and
+  performance of their team and/or direct reports.
+- [ ] Consistently seeks to improve processes at the company such as interview
+  practices, onboarding, defining roles, etc.
+
+### Coaching and mentoring
+- [ ] Provides timely and actionable feedback via regular 1:1s.
+- [ ] Motivates direct reports to keep them ascending the career ladder for both
+  the IC and EM tracks and uses the career ladders to keep track of their
+  progress.
+- [ ] Coaches developers on how to set goals that push them out of their comfort
+  zone and assists them in succeeding.
+- [ ] Deals with performance issues and misaligned expectations and understands
+  their role in bringing an employee back on track.
+- [ ] Empowers direct reports to own their work.
+- [ ] Ensures direct reports are aware of growth and learning opportunities and
+  helps them leverage these.
+
+### Management/HR
+- [ ] Manages compensation changes and promotions in collaboration with the CTO.
+- [ ] Coordinates vacation with the direct report, product manager, traffic
+  manager, or other relevant parties.
+- [ ] Manages the development budget for direct reports and assists them with
+  practical matters when necessary.
+- [ ] Runs yearly 360 reviews with their direct reports.
+- [ ] Partners closely with the CTO to set the direction for the team and
+  proactively provides updates on progress.
+
+## Technical skills
+- [ ] Focuses on implementing features and bug fixes without blocking the team.
+- [ ] Sets high technical standards but knows when to make pragmatic tradeoffs.
+
+### Communication and facilitation
+- [ ] Attends early meetings with clients to set realistic expectations with
+  sales and the client.
+- [ ] Uses their experience to identify headcount needs when planning new
+  projects.
+- [ ] Communicates strategy and progress within the team and to external
+  stakeholders.
+- [ ] Encourages effective meetings with clear agendas/purpose and actions.
+- [ ] Resolves tension, interpersonal and technical conflicts within the team.
+- [ ] Clearly communicates expectations.
+- [ ] Ensures new hires are onboarded successfully in collaboration with
+  relevant parties.
+
+## Level 2
+- TBD.
+
+## Level 3
+- TBD.
+
+## Level 4
+- TBD.
+
+## Level 5
+- TBD.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -36,8 +36,8 @@ make pull requests with suggestions for improvements.
 - [ ] Manages compensation changes and promotions in collaboration with the CTO.
 - [ ] Coordinates vacation with the direct report, product manager, traffic
   manager, or other relevant parties.
-- [ ] Manages the development budget for direct reports and assists them with
-  practical matters when necessary.
+- [ ] Approves/suggests uses of the direct report's development budget and
+  assists them with practical matters when necessary.
 - [ ] Runs yearly 360 reviews with their direct reports.
 - [ ] Partners closely with the CTO to set the direction for the team and
   proactively provides updates on progress.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -27,7 +27,8 @@ client projects.
   practices, onboarding, defining roles, etc.
 
 ### Coaching and mentoring
-- [ ] Provides timely and actionable feedback via regular 1:1s.
+- [ ] Provides direct reports, manager, product managers etc. with timely and
+  actionable feedback.
 - [ ] Motivates direct reports to keep them ascending the career ladder for both
   the IC and EM tracks and uses the career ladders to keep track of their
   progress.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -13,9 +13,7 @@ make pull requests with suggestions for improvements.
 
 ## Level 3: Associate Engineering Manager
 ### Impactful
-- [ ] Manages a set of people consisting of four to five direct reports.
-- [ ] Has the required maturity to manage individual contributors at a higher
-  skill level than themselves.
+- [ ] Manages a set of people consisting of approximately two direct reports.
 - [ ] Identifies growth opportunities for their direct reports and proactively
   ensures that these opportunities are pursued.
 - [ ] Adjusts processes and practices regularly to maximize the efficiency and
@@ -30,8 +28,6 @@ make pull requests with suggestions for improvements.
   progress.
 - [ ] Coaches developers on how to set goals that push them out of their comfort
   zone and assists them in succeeding.
-- [ ] Deals with performance issues and misaligned expectations and understands
-  their role in bringing an employee back on track.
 - [ ] Empowers direct reports to own their work.
 - [ ] Ensures direct reports are aware of growth and learning opportunities and
   helps them leverage these.
@@ -53,8 +49,6 @@ make pull requests with suggestions for improvements.
 ### Communication and facilitation
 - [ ] Attends early meetings with clients to set realistic expectations with
   sales and the client.
-- [ ] Uses their experience to identify headcount needs when planning new
-  projects.
 - [ ] Communicates strategy and progress within the team and to external
   stakeholders.
 - [ ] Encourages effective meetings with clear agendas/purpose and actions.
@@ -64,7 +58,24 @@ make pull requests with suggestions for improvements.
   relevant parties.
 
 ## Level 4: Engineering Manager
+### Impactful
+- [ ] Manages a set of people consisting of approximately four direct reports.
+- [ ] Has the required maturity to manage individual contributors at a higher
+  skill level than themselves.
+
+### Coaching and mentoring
+- [ ] Deals with performance issues and misaligned expectations and understands
+  their role in bringing an employee back on track.
+
+### Management/HR
 - TBD.
+
+## Technical skills
+- TBD.
+
+### Communication and facilitation
+- [ ] Uses their experience to identify headcount needs when planning new
+  projects.
 
 ## Level 5: Engineering Manager
 - TBD.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -2,11 +2,12 @@
 This career ladder serves to give an overview of how you can progress your
 career at Abtion and become an Engineering Manager (EM).
 
-As a prerequisite, we require people to have moved beyond level 2 on our [IC
-career ladder](https://github.com/abtion/guidelines/blob/main/career/ladder.md)
-before they can transition into a role as an Engineering Manager. This is
-required as we believe it is important that you have grown your technical
-skills to a certain level before you start leading highly technical individuals.
+As a prerequisite, we require people to have moved beyond level 2 on our
+[individual contributor (IC) career
+ladder](https://github.com/abtion/guidelines/blob/main/career/ladder.md) before
+they can transition into a role as an Engineering Manager. This is required as
+we believe it is important that you have grown your technical skills to a
+certain level before you start leading highly technical individuals.
 
 Engineering managers are expected to be able to check off most items under
 "Impactful", "Simple", "Communication" and "Respectful teammate" for the

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -89,6 +89,8 @@ projects.
 - [ ] Manages a set of people consisting of approximately four direct reports.
 - [ ] Has the required maturity to manage individual contributors at a higher
   skill level than themselves.
+- [ ] Uses their experience and relevant data to make fast and informed
+  decisions.
 
 ### Coaching and mentoring
 - [ ] Deals with performance issues and misaligned expectations and understands

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -42,10 +42,6 @@ make pull requests with suggestions for improvements.
 - [ ] Partners closely with the CTO to set the direction for the team and
   proactively provides updates on progress.
 
-## Technical skills
-- [ ] Focuses on implementing features and bug fixes without blocking the team.
-- [ ] Sets high technical standards but knows when to make pragmatic tradeoffs.
-
 ### Communication and facilitation
 - [ ] Attends early meetings with clients to set realistic expectations with
   sales and the client.
@@ -70,9 +66,6 @@ make pull requests with suggestions for improvements.
 ### Management/HR
 - TBD.
 
-## Technical skills
-- TBD.
-
 ### Communication and facilitation
 - [ ] Uses their experience to identify headcount needs when planning new
   projects.
@@ -85,9 +78,6 @@ make pull requests with suggestions for improvements.
 - TBD.
 
 ### Management/HR
-- TBD.
-
-## Technical skills
 - TBD.
 
 ### Communication and facilitation
@@ -103,9 +93,6 @@ make pull requests with suggestions for improvements.
 ### Management/HR
 - TBD.
 
-## Technical skills
-- TBD.
-
 ### Communication and facilitation
 - TBD.
 
@@ -117,9 +104,6 @@ make pull requests with suggestions for improvements.
 - TBD.
 
 ### Management/HR
-- TBD.
-
-## Technical skills
 - TBD.
 
 ### Communication and facilitation

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -96,6 +96,8 @@ projects.
 ### Coaching and mentoring
 - [ ] Deals with performance issues and misaligned expectations and understands
   their role in bringing an employee back on track.
+- [ ] Assists new engineering managers in how they can better plan and support
+  the growth of their direct reports.
 
 ### Management/HR
 - TBD.
@@ -115,7 +117,7 @@ projects.
   reports.
 
 ### Coaching and mentoring
-- TBD.
+- [ ] Coaches new engineering managers and uses their experience to grow them.
 
 ### Management/HR
 - TBD.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -8,6 +8,14 @@ before they can transition into a role as an Engineering Manager. This is
 required as we believe it is important that you have grown your technical
 skills to a certain level before you start leading highly technical individuals.
 
+While the engineering management track includes non-development tasks, it is
+worth pointing out that most of your time will still be spent on development and
+other client-focused work. You will gradually spend more time on managerial
+tasks as you move up the career ladder but check the "Time expectation" section
+under each level to see how your time will be split. EM-related tasks include,
+but are not limited to, 360 reviews, 1-on-1s, administrative work and attending
+engineering management meetings.
+
 Any feedback on this career ladder is appreciated, and we encourage that you
 make pull requests with suggestions for improvements.
 

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -91,6 +91,7 @@ projects.
   skill level than themselves.
 - [ ] Uses their experience and relevant data to make fast and informed
   decisions.
+- [ ] Has a track record of growing people across various teams.
 
 ### Coaching and mentoring
 - [ ] Deals with performance issues and misaligned expectations and understands

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -76,6 +76,8 @@ client projects.
 - [ ] Clearly communicates expectations.
 - [ ] Ensures new hires are onboarded successfully in collaboration with
   relevant parties.
+- [ ] Drives and organizes the hiring/interview process in collaboration
+  with the Executive Assistant.
 
 ## Level 4: Engineering Manager
 **Time expectation**: Engineering Managers are expected to use about 30 percent

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -113,16 +113,3 @@ projects.
 
 ### Communication and facilitation
 - TBD.
-
-## Level 7: Senior Engineering Manager
-### Impactful
-- TBD.
-
-### Coaching and mentoring
-- TBD.
-
-### Management/HR
-- TBD.
-
-### Communication and facilitation
-- TBD.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -12,6 +12,11 @@ Any feedback on this career ladder is appreciated, and we encourage that you
 make pull requests with suggestions for improvements.
 
 ## Level 3: Associate Engineering Manager
+**Time expectation**: Associate Engineering Managers are expected to use about
+20 percent of their time (~5.5 hours/week) on non-billable/EM-related tasks. The
+remaining time will be spent on development or other activities related to
+client projects.
+
 ### Impactful
 - [ ] Manages a set of people consisting of approximately two direct reports.
 - [ ] Identifies growth opportunities for their direct reports and proactively
@@ -54,6 +59,11 @@ make pull requests with suggestions for improvements.
   relevant parties.
 
 ## Level 4: Engineering Manager
+**Time expectation**: Engineering Managers are expected to use about 30 percent
+of their time (~8 hours/week) on non-billable/EM-related tasks. The remaining
+time will be spent on development or other activities related to client
+projects.
+
 ### Impactful
 - [ ] Manages a set of people consisting of approximately four direct reports.
 - [ ] Has the required maturity to manage individual contributors at a higher
@@ -71,6 +81,11 @@ make pull requests with suggestions for improvements.
   projects.
 
 ## Level 5: Engineering Manager
+**Time expectation**: Engineering Managers are expected to use about 40 percent
+of their time (~10 hours/week) on non-billable/EM-related tasks. The remaining
+time will be spent on development or other activities related to client
+projects.
+
 ### Impactful
 - [ ] Manages a set of people consisting of approximately six to eight direct
   reports.

--- a/career/em-ladder.md
+++ b/career/em-ladder.md
@@ -38,7 +38,8 @@ client projects.
   helps them leverage these.
 
 ### Management/HR
-- [ ] Manages compensation changes and promotions in collaboration with the CTO.
+- [ ] Suggests compensation changes and manages promotions in collaboration with
+  the CTO.
 - [ ] Coordinates vacation with the direct report, product manager, traffic
   manager, or other relevant parties.
 - [ ] Approves/suggests uses of the direct report's development budget and


### PR DESCRIPTION
As we've talked about a few times now, we need an EM career ladder. This pull request provides a draft of what such a ladder might look like.

For now, I've mostly focused on level 3, but if it makes sense, we could consider moving some of the points into later levels. Most larger corporations seem to divide these levels into Engineering Manager, Senior Engineering Manager, Head of Engineering, Director of Engineering, and Vice President of Engineering. I am not sure these titles make sense in a company of our size, though, but let me know what you think.

Also, I've noted it as a prerequisite that you are at least on level 2 in the existing IC career ladder since I think it is quite important that you have sharpened your technical skills before you move into a role as an Engineering Manager. At the same time, though, I also want to acknowledge the fact that EMs are not ICs, and the expectations, therefore, are different for the two tracks.

@hcarreras: Are EMs responsible for managing contract changes? Who puts their name on contracts etc.? Is this something we want to cover in the career ladder?