### PR TITLE
Sharing sensitive information

### DIFF
--- a/tools_and_services/sharing_sensitive_information.md
+++ b/tools_and_services/sharing_sensitive_information.md
@@ -1,0 +1,12 @@
+# 1password
+
+All credentials and sensitive information used by a team must be hosted on 1password. 
+See [Access and Permissions](https://github.com/abtion/guidelines/blob/main/tools_and_services/access_and_permissions.md) for more on how we organize vaults.
+Note that external members can be invited to the vault. It is common to share a vault with a client's team.
+If someone from Abtion needs access to information stored in the vault, the person should request access to the vault. 
+
+# Abtion's best-kept secret
+
+When we need to share sensitive information with someone who is not part of 1password, we use secret.abtion.com. 
+There, we can put any text and generate a safe link that can only be seen once and expires in 24 hours if it's not opened in that time. 
+Note that we need to inform the client on how the webpage works. Remember to ask the receiver to store the shared information safely.


### PR DESCRIPTION
Adding 1password as a default way of sharing information and our newly created secret.abtion.com as the way to share one-off information with externals.