### PR TITLE
Update tooling around git blame when pairing

### DIFF
--- a/setup/pairing_setup.md
+++ b/setup/pairing_setup.md
@@ -2,13 +2,13 @@
 
 ### Committing as a pair
 
-We are using [git pair script from pivotal-legacy](https://github.com/pivotal-legacy/git_scripts)
+One of the many useful features of git, is the ability to know who may have knowledge about a specific part of the code. Git blame may have a terrible name, but it comes handy at times.
 
-```
-gem install pivotal_git_scripts
-```
+A side effect of pairing is that we lose half of the information of who coded something, as the default contributor is the developer who is hosting the pairing session.
 
-See more setup instructions in the repo (RubyMine etc).
+To remediate this, we have to manually co-author our commit messages.
+
+To make this task a bit easier, we have [a repo that hosts the accounts of our contributors](https://github.com/abtion/gitmessage).
 
 ### Using different keyboard layouts
 


### PR DESCRIPTION
We do not use Pivotal's tool anymore, but simply the co-author label.