### PR TITLE
CI: Add markdown-link-check

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,13 @@
+name: Check broken links in markdown
+
+on:
+  # Triggers the workflow every Monday at 9AM
+  schedule:
+    - cron: "0 9 * * 1"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,6 +1,7 @@
 name: Check broken links in markdown
 
 on:
+  push:
   # Triggers the workflow every Monday at 9AM
   schedule:
     - cron: "0 9 * * 1"

--- a/career/engineering_manager_career_ladder.md
+++ b/career/engineering_manager_career_ladder.md
@@ -5,7 +5,7 @@ career at Abtion and become an Engineering Manager (EM).
 
 As a prerequisite, we require people to have moved beyond level 2 on our
 [individual contributor (IC) career
-ladder](https://github.com/abtion/guidelines/blob/main/career/ladder.md) before
+ladder](./software_engineer_progression_framework.md) before
 they can transition into a role as an Engineering Manager. This is required as
 we believe it is important that you have grown your technical skills to a
 certain level before you start leading highly technical individuals.
@@ -13,7 +13,7 @@ certain level before you start leading highly technical individuals.
 Engineering managers are expected to be able to check off most items under
 "Impactful", "Simple", "Communication" and "Respectful teammate" for the
 corresponding level in the [IC career
-ladder](https://github.com/abtion/guidelines/blob/main/career/ladder.md).
+ladder](./software_engineer_progression_framework.md).
 Although you will not be evaluated on your ability to test highly complex logic,
 we believe testing is an essential engineering practice that you will continue
 honing and teaching.

--- a/employee_manual/safety_and_security.md
+++ b/employee_manual/safety_and_security.md
@@ -8,7 +8,7 @@ Along with a shared vault, will you have storage for your own private passwords.
 
 - In 1pw you can find log-in credentials to internal stuff like WiFi-code, internal used applications and access to project related data. 
 
-- [Managing access to 1pw vaults and project data](https://abtion.github.io/guidelines/tools_and_services/managing_access_to_1pw_vaults_and_project_data.html) introduces you to our way of working with 1pw. The magic to keep it all nice and tight, we educate ourselves to be our own gatekeeper. Everyone is actively contributing to the main rules and culture.
+- [Managing access to 1pw vaults and project data](../tools_and_services/access_and_permissions.md) introduces you to our way of working with 1pw. The magic to keep it all nice and tight, we educate ourselves to be our own gatekeeper. Everyone is actively contributing to the main rules and culture.
 
 ### Security Policy
 

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -17,6 +17,9 @@
       "pattern": "^https://github.com/abtion/gitmessage"
     },
     {
+      "pattern": "^https://(www.)?linkedin.com"
+    },
+    {
       "pattern": "^https://abtion.io"
     }
   ]

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,13 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https?://app.asana.com"
+    },
+    {
+      "pattern": "^https://github.com/abtion/gitmessage"
+    },
+    {
+      "pattern": "^https://abtion.io"
+    }
+  ]
+}

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,4 +1,14 @@
 {
+  "httpHeaders": [
+    {
+      "urls": [
+        "https://docs.github.com/"
+      ],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ],
   "ignorePatterns": [
     {
       "pattern": "^https?://app.asana.com"

--- a/project_management/handoffs.md
+++ b/project_management/handoffs.md
@@ -5,7 +5,7 @@
 ### Two weeks prior
 
 1. Write an email to the internal and the clients PMs to set a date and clarify any expectations around the handoff at the projects end.
-2. Be sure you have a complete [README](https://github.com/abtion/guidelines/blob/main/README.standard.md). Including:
+2. Be sure you have a complete [README](../templates/README.standard.md). Including:
     1. Any diagrams
     2. Introductions to noteable inclusions
     3. Known issues
@@ -46,7 +46,7 @@
 ### Two weeks prior
 
 1. Write an email to the internal and the clients PMs to set a date and clarify any expectations around the handoff at the projects end.
-2. Be sure you have a complete [README](https://github.com/abtion/guidelines/blob/main/README.standard.md). Including:
+2. Be sure you have a complete [README](../templates/README.standard.md). Including:
     1. Any diagrams
     2. Introductions to noteable inclusions
     3. Known Issues

--- a/setup/gpg_signing.md
+++ b/setup/gpg_signing.md
@@ -9,14 +9,14 @@ Install gpg via homebrew: `brew install gpg`
 ## Create GPG Key
 
 Set up a GPG key for your GitHub account by following the Github guide:
-[Generating a new GPG key](https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key)
+[Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key)
 
 Save your GPG signing key in 1Password.
 
 ## Adding the new GPG key to your GitHub account
 
 Add the GPG key to your GitHub account (This is step 14 from the "Generating a new GPG key" guide)
-[Adding the new GPG key](https://docs.github.com/en/github/authenticating-to-github/adding-a-new-gpg-key-to-your-github-account)
+[Adding the new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-new-gpg-key-to-your-github-account)
 
 ## Configure git to default to signed commits
 

--- a/technical_practices/bug_triaging.md
+++ b/technical_practices/bug_triaging.md
@@ -29,6 +29,6 @@ Code needs to be test-driven and written in pairs. This is the Abtion way and
 has proven to minimize bugs.
 
 ## Additional reading
-- [Bug Triage - Mozilla | MDN](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Helping_the_DOM_team/Bug_Triage)
+- [Triage process for MDN content bugs - Mozilla | MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Processes/Content_bug_triage)
 - [Bug management/How to triage - MediaWiki](https://www.mediawiki.org/wiki/Bug_management/How_to_triage)
 - [Triaging Bugs - The Chromium Projects](http://www.chromium.org/getting-involved/bug-triage)

--- a/technical_practices/workflow.md
+++ b/technical_practices/workflow.md
@@ -28,7 +28,7 @@ Following a trunk-based development workflow means that some pre-integration ste
 - A pair always takes the first card from the backlog. The backlog is already prioritized.
 - A pair will pull from `main`* and make sure to be up-to-date with the latest changes.
 - A pair will work on the card until it is ready. Pair switches might occur during the process.
-- Every commit is [signed](https://github.com/abtion/guidelines/tree/main/gpg-signing), [Co-authored](https://github.blog/2018-01-29-commit-together-with-co-authors/), and has passed the `pre-commit` hooks.
+- Every commit is [signed](../setup/gpg_signing.md), [Co-authored](https://github.blog/2018-01-29-commit-together-with-co-authors/), and has passed the `pre-commit` hooks.
 - When the work is done, the pair pushes the changes. This will trigger the `pre-push` hooks and ensure the changes' validity.
 - Github Actions (or pragmatically-picked alternatives) are used for continuous integration.
 - We automatically deploy to production. We may use a test environment** which must always be synchronized with production with private information obfuscated for security. We may use feature flags for coordinating feature releases with the client.
@@ -39,7 +39,7 @@ Following a trunk-based development workflow means that some pre-integration ste
 - The developers have the responsibility to move the card to a "Ready for acceptance” column in Asana. This implies that they genuinely believe the card is ready. The card is assigned to the tester.
 - If the backlog runs out of tasks, developers will let the product owner know, and will work on technical debt until the product owner has prioritized feature work.
 
-\* `main` might have a different name depending on the project. We strive to use an [inclusive language](https://github.com/abtion/guidelines/blob/main/best-practices/inclusive-language.md)
+\* `main` might have a different name depending on the project. We strive to use an [inclusive language](../behaviour_and_protocol/inclusive_language.md)
 
 ** called staging in Heroku. Do not confuse with staging from git-flow.
 

--- a/tools_and_services/preferred_services.md
+++ b/tools_and_services/preferred_services.md
@@ -13,15 +13,15 @@ If there is a service in this category, but the team wants to use a different on
 ![](https://via.placeholder.com/10/00c900/?text=+) [InMobile](https://www.inmobile.com/)
 
 ### Error management
-![](https://via.placeholder.com/10/00c900/?text=+) [Rollbar](rollbar.com) In Heroku: use the addon. Default configuration on [Muffi Rails](https://github.com/abtion/muffi).
-![](https://via.placeholder.com/10/ffff00/?text=+) [Sentry](sentry.io) In Heroku: use the addon.
+![](https://via.placeholder.com/10/00c900/?text=+) [Rollbar](https://rollbar.com) In Heroku: use the addon. Default configuration on [Muffi Rails](https://github.com/abtion/muffi).
+![](https://via.placeholder.com/10/ffff00/?text=+) [Sentry](https://sentry.io) In Heroku: use the addon.
 
 ### Mailing
 ![](https://via.placeholder.com/10/f03c15/?text=+) [SendInBlue](https://www.sendinblue.com/): You'll need to manually create a project account. Default configuration on [Muffi Rails](https://github.com/abtion/muffi). Remember to set up DKIM.
 
 ![](https://via.placeholder.com/10/f03c15/?text=+) [SendGrid](https://sendgrid.com/) Countless issues when using the addon on Heroku. Accounts are banned on regular basis.
 
-![](https://via.placeholder.com/10/f03c15/?text=+) [MailGun](mailgun.com) Countless issues when using the addon on Heroku. Accounts are banned on regular basis.
+![](https://via.placeholder.com/10/f03c15/?text=+) [MailGun](https://mailgun.com) Countless issues when using the addon on Heroku. Accounts are banned on regular basis.
 
 ### Mail testing
 ![](https://via.placeholder.com/10/ffff00/?text=+) Use [mail-tester](https://www.mail-tester.com) to test mail setup.

--- a/tools_and_services/sharing_sensitive_information.md
+++ b/tools_and_services/sharing_sensitive_information.md
@@ -1,7 +1,7 @@
 # 1password
 
 All credentials and sensitive information used by a team must be hosted on 1password. 
-See [Access and Permissions](https://github.com/abtion/guidelines/blob/main/tools_and_services/access_and_permissions.md) for more on how we organize vaults.
+See [Access and Permissions](./access_and_permissions.md) for more on how we organize vaults.
 Note that external members can be invited to the vault. It is common to share a vault with a client's team.
 If someone from Abtion needs access to information stored in the vault, the person should request access to the vault. 
 


### PR DESCRIPTION
This will add the GitHub Action for [Markdown Link Check](https://github.com/tcort/markdown-link-check).

I'm unsure about whether to run the Action on a schedule or for every push (or both):
Running it on a schedule will allow us to catch links that broke by themselves.
Running it on push will allow us to catch broken links that we just added.

Thoughts?

The `mlc_config.json` file is set to:
- Add headers to GitHub Docs links.
GitHub throws a 403 error, when headers aren't added
- Ignore internal Asana links
- Ignore the gitmessage repo
- Ignore LinkedIn links
LinkedIn throws a [status 999](https://wiert.me/2019/10/23/when-linkedin-throws-http-result-code-999-at-you-it-means-it-does-not-like-you) to avoid anyone from requesting the site programatically
- Ignore the abtion.io website
Because it's password-protected