### PR TITLE
Setup Github branch protection rules

### DIFF
--- a/project_management/Technical_setup_when_starting_a_new_project.md
+++ b/project_management/Technical_setup_when_starting_a_new_project.md
@@ -70,6 +70,16 @@ Setup automerge github action
   - create github automerge action
     - copy auto-merge.yml, dependabot.yml, workflows/auto-merge-dependabot.yml from [muffi/.github](https://github.com/abtion/muffi/tree/main/.github) into [clientname]-[projectname]/.github
 
+Repo settings
+  - Disallow `Allow rebase merging` (because it is incompatible with `Require signed commits`)
+  - Enable `Allow auto-merge`
+  - Enable `Automatically delete head branches Loading`
+  - Enable `Always suggest updating pull request branches`
+  - Setup `Rules`. Add a branch ruleset
+    - In addition to the defaults make the following changes:
+    - Target branch: Include default branch
+    - Enable `Require signed commit`
+
 ## *4. Heroku project setup (NOT relevant for all projects)
 - create a new account [clientname]@abtion.com
 - create a new team [clientname]


### PR DESCRIPTION
Github's "rebase and merge" option and their branch protection rule "require signed commit" are incompatible. They have various documentation pages about the two options, but only two of them mention this incompatibility https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-rebase-and-merge. Very annoying.

We have previously enforced our policy (https://inside.abtion.com/technical_practices/workflow.html) about enabling branch protection with "require signed commits", but now a lot of repositories do not have this enabled anymore. In the meantime, a lot of repositories have had "Allow merge commits" disabled for their pull requests (because some people dislike merge commits).

What should we do about this?
I like the policy about requiring signed commits.
I also like merge commits.

So my suggestion is to disable "Allow rebase merging" on pull requests, and keep the two other merging options enabled.