### PR TITLE
Add CMS selection guide with Payload

### DIFF
--- a/tools_and_services/stack_and_services.md
+++ b/tools_and_services/stack_and_services.md
@@ -48,7 +48,7 @@ Use this table to pick the right CMS based on how much content flexibility the c
 |---|---|
 | High — customizable pages with blocks that change | WordPress |
 | Medium — change text and assets in a rigid structure | 🟡 Payload |
-| Low — no changes expected | Webflow or plain React |
+| Low — no changes expected | [Webflow](https://webflow.com/) or None (plain React) |
 
 - 🔴 [Strapi](https://strapi.io/) — previously used, no longer recommended as default
 - 🟡 [Payload](https://payloadcms.com/) — best candidate so far for default CMS on medium-complexity projects; schema-as-code, self-hostable, strong TypeScript/Next.js integration

--- a/tools_and_services/stack_and_services.md
+++ b/tools_and_services/stack_and_services.md
@@ -35,11 +35,23 @@ Finding a balance between trying out something new or using a well-known tool is
 
 ### Websites
 
-- [Strapi](https://strapi.io/) as CMS
 - [Next.js](nextjs.org/) as frontend (with or without CMS)
 - [WordPress](https://wordpress.com/)\*
 
 \* WordPress has its own [guideline](wordpress) as it's a whole separate ecosystem
+
+#### CMS
+
+Use this table to pick the right CMS based on how much content flexibility the client needs:
+
+| Customization needs | CMS |
+|---|---|
+| High — customizable pages with blocks that change | WordPress |
+| Medium — change text and assets in a rigid structure | 🟡 Payload |
+| Low — no changes expected | Webflow or plain React |
+
+- 🔴 [Strapi](https://strapi.io/) — previously used, no longer recommended as default
+- 🟡 [Payload](https://payloadcms.com/) — best candidate so far for default CMS on medium-complexity projects; schema-as-code, self-hostable, strong TypeScript/Next.js integration
 
 ### Mobile apps
 


### PR DESCRIPTION
## What

Updates the [Stack & Services](https://inside.abtion.com/tools_and_services/stack_and_services.html) guidelines with a CMS recommendation following the evaluation done in [ABT-41](https://linear.app/abtion/issue/ABT-41).

- Adds a CMS selection table mapping client customization needs to the right tool
- Adds **Payload** 🟡 as the best candidate for medium-complexity projects (schema-as-code, self-hostable, strong TypeScript/Next.js fit)
- Marks **Strapi** 🔴 as no longer recommended (previously default)
- Removes Strapi from the top-level Websites list and consolidates CMS options under a dedicated `#### CMS` subsection

Directus was ruled out due to a licensing change.

## How to test (developer)

- [ ] Visit the rendered page at https://inside.abtion.com/tools_and_services/stack_and_services.html after merge and confirm the CMS section appears under **Websites** with the selection table and both Payload and Strapi entries.
- [ ] Confirm Payload has a 🟡 indicator and Strapi has a 🔴 indicator.