### PR TITLE
Remove parental plan development bullet from parental leave policy

### DIFF
--- a/employee_manual/parental_leave_policy.md
+++ b/employee_manual/parental_leave_policy.md
@@ -11,7 +11,6 @@ Our policy allows for full salary during parental leave for a period of up to a 
 ### Before parental leave:
 
 - Pre-leave consultation: We offer a meeting with an external parental consultant to all expectant employees. This consultation will assist you in creating a personalized parental plan for you and your partner, addressing any concerns, and setting expectations for your leave and return.
-- Parental plan development: Together with the parental consultant, you will develop a comprehensive parental plan that outlines your work transition, covering all aspects from the start of your leave to your return. See the details of the parental consultant at [barselseksperten.dk](https://www.barselseksperten.dk/barselsplanforaeldre)
 - Agreements with manager: It is your responsibility to provide your parental leave plan to your manager. Agree with your manager first the temporary dates of your leave for forecast and then the exact date when you know.
 - Abtion offers access to the "Barselspakke" from Klinik for Kvindekroppen to support recovery and well-being after childbirth. This package provides postnatal care, including physical therapy and recovery guidance, and is available for employees or their partner. The package is fully covered by Abtion. For details, visit [Klinik for Kvindekroppen](https://klinikforkvindekroppen.dk/barselspakke-for-virksomheder)
 


### PR DESCRIPTION
Removes the "Parental plan development" bullet from the *Before parental leave* section of `employee_manual/parental_leave_policy.md`, including the reference to the external parental consultant at barselseksperten.dk.

The section now flows from the pre-leave consultation bullet directly to the "Agreements with manager" bullet.

Slack thread: https://abtion.slack.com/archives/D0AKVA0MQ74/p1782111411083899?thread_ts=1782111344.689379&cid=D0AKVA0MQ74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RM1u4qxsZrbMxWveHAnqNY)_